### PR TITLE
Fix HTML5 not using build flags.

### DIFF
--- a/source/Init.hx
+++ b/source/Init.hx
@@ -8,6 +8,7 @@ import states.*;
 
 class Init extends MusicBeatState
 {
+	var openWarningMenu:Bool = false;
 	override function create()
 	{
 		super.create();
@@ -28,15 +29,24 @@ class Init extends MusicBeatState
 	function firstState()
 	{
 		#if html5
-		Main.switchState(new WarningState());
-		#elseif MENU
+		openWarningMenu = true;
+		#end
+		if(FlxG.save.data.beenWarned == null || openWarningMenu)
+			Main.switchState(new WarningState());
+		else
+			Main.switchState(new TitleState());
+	}
+	/*
+	A function to call some of the engines build flags from
+	other states.
+	*/
+	public static function flagStates()
+	{
+		#if MENU
 		Main.switchState(new states.menu.MainMenuState());
 		#elseif FREEPLAY
 		Main.switchState(new states.menu.FreeplayState());
 		#else
-		if(FlxG.save.data.beenWarned == null)
-			Main.switchState(new WarningState());
-		else
 			Main.switchState(new TitleState());
 		#end
 	}

--- a/source/Init.hx
+++ b/source/Init.hx
@@ -8,7 +8,6 @@ import states.*;
 
 class Init extends MusicBeatState
 {
-	var openWarningMenu:Bool = false;
 	override function create()
 	{
 		super.create();
@@ -28,26 +27,26 @@ class Init extends MusicBeatState
 
 	function firstState()
 	{
-		#if html5
-		openWarningMenu = true;
-		#end
+		var openWarningMenu:Bool = #if html5 true #else false #end;
+
 		if(FlxG.save.data.beenWarned == null || openWarningMenu)
 			Main.switchState(new WarningState());
 		else
 			Main.switchState(new TitleState());
 	}
+
 	/*
-	A function to call some of the engines build flags from
-	other states.
+	* A function to call some of the engines build flags from
+	* other states.
 	*/
-	public static function flagStates()
+	public static function flagState()
 	{
 		#if MENU
 		Main.switchState(new states.menu.MainMenuState());
 		#elseif FREEPLAY
 		Main.switchState(new states.menu.FreeplayState());
 		#else
-			Main.switchState(new TitleState());
+		Main.switchState(new TitleState());
 		#end
 	}
 }

--- a/source/states/WarningState.hx
+++ b/source/states/WarningState.hx
@@ -29,7 +29,7 @@ class WarningState extends MusicBeatState
 		
 		if(Controls.justPressed(ACCEPT))
 		{
-           	Init.flagStates();
+           	Init.flagState();
 
             FlxG.save.data.beenWarned = true;
             FlxG.save.flush();

--- a/source/states/WarningState.hx
+++ b/source/states/WarningState.hx
@@ -29,7 +29,7 @@ class WarningState extends MusicBeatState
 		
 		if(Controls.justPressed(ACCEPT))
 		{
-            Main.switchState(new states.TitleState());
+           	Init.flagStates();
 
             FlxG.save.data.beenWarned = true;
             FlxG.save.flush();


### PR DESCRIPTION
Fixes a small issue, where building HTML5 doesn't follow the build flags. This is caused due to the flags not being specified in `WarningState`.