### PR TITLE
override cliprect setter to prevent the clipping from looking jittery

### DIFF
--- a/source/objects/note/Note.hx
+++ b/source/objects/note/Note.hx
@@ -2,6 +2,7 @@ package objects.note;
 
 import flixel.FlxSprite;
 import flixel.math.FlxPoint;
+import flixel.math.FlxRect;
 import backend.song.Conductor;
 
 class Note extends FlxSprite
@@ -206,5 +207,16 @@ class Note extends FlxSprite
 		
 		clipRect = null;
 		setAlpha();
+	}
+
+	@:noCompletion
+	override function set_clipRect(rect:FlxRect):FlxRect
+	{
+		clipRect = rect;
+
+		if (frames != null)
+			frame = frames.frames[animation.frameIndex];
+
+		return rect;
 	}
 }


### PR DESCRIPTION
i noticed the clipping on holds look weird when the bpm is low with high scroll speeds if i look closely
you can notice this a little more by enabling segmented holds