### PR TITLE
Fix HTML5 having a small window.

### DIFF
--- a/Project.xml
+++ b/Project.xml
@@ -18,7 +18,7 @@
 	<window width="1280" height="720" fps="144" background="#000000" hardware="true" vsync="false" />
 
 	<!--HTML5-specific-->
-	<window if="html5" resizable="false" />
+	<window if="html5" resizable="true" />
 
 	<!--Desktop-specific-->
 	<window if="desktop" orientation="landscape" fullscreen="false" resizable="true" />


### PR DESCRIPTION
Fixes a small issue with HTML5 where the window doesn't get resized to the full screen available screen size. This is especially bad for people with larger resolution sizes.

BEFORE:

<img width="2532" height="1279" alt="image" src="https://github.com/user-attachments/assets/10a56d8b-da20-48c9-838c-d808c07184da" />

AFTER:

<img width="2556" height="1277" alt="image" src="https://github.com/user-attachments/assets/bf096b97-e817-4b56-85c4-2acb867d8d0f" />
