### PR TITLE
Disable F5 to reload on certain states.

### DIFF
--- a/source/doido/MusicBeat.hx
+++ b/source/doido/MusicBeat.hx
@@ -21,7 +21,6 @@ class MusicBeat
 {
 	public static var activeState:FlxState;
 	public static var nextTransition:String = '';
-
 	public static function switchState(?target:MusicBeatState, tOut:String = 'funkin', ?tIn:String)
 	{
 		#if SCREENSHOT_FEATURE Screenshot.clearScreenshot(); #end
@@ -178,6 +177,7 @@ class MusicBeatState extends FlxUIState
 {
 	public var onInputChange(default, null):InputSignal = new InputSignal();
 	public var loadedScripts:Array<Iris> = [];
+	public static var disableHotReload:Bool = false;
 
 	override function create()
 	{
@@ -229,7 +229,7 @@ class MusicBeatState extends FlxUIState
 		MusicBeat.updateConductor();
 		updateStep();
 
-		if (FlxG.keys.justPressed.F5)
+		if (FlxG.keys.justPressed.F5 && !disableHotReload)
 			resetState();
 	}
 

--- a/source/doido/MusicBeat.hx
+++ b/source/doido/MusicBeat.hx
@@ -177,7 +177,6 @@ class MusicBeatState extends FlxUIState
 {
 	public var onInputChange(default, null):InputSignal = new InputSignal();
 	public var loadedScripts:Array<Iris> = [];
-	public static var disableHotReload:Bool = false;
 
 	override function create()
 	{
@@ -217,6 +216,7 @@ class MusicBeatState extends FlxUIState
 	}
 
 	private var _curStep = 0; // actual curStep
+	private var hotReload:Bool = true;
 
 	public var curStep = 0;
 	public var curStepFloat:Float = 0;
@@ -229,7 +229,7 @@ class MusicBeatState extends FlxUIState
 		MusicBeat.updateConductor();
 		updateStep();
 
-		if (FlxG.keys.justPressed.F5 && !disableHotReload)
+		if (FlxG.keys.justPressed.F5 && hotReload)
 			resetState();
 	}
 

--- a/source/doido/system/CrashHandler.hx
+++ b/source/doido/system/CrashHandler.hx
@@ -22,6 +22,7 @@ class CrashHandler extends MusicBeatState
 	override function create()
 	{
 		super.create();
+		MusicBeatState.disableHotReload = true;
 		var bg = new FlxSprite().loadGraphic(Assets.image('menuInvert'));
 		bg.screenCenter();
 		bg.alpha = 0.4;
@@ -63,17 +64,18 @@ class CrashHandler extends MusicBeatState
 	override function update(elapsed:Float)
 	{
 		super.update(elapsed);
-		if (FlxG.keys.justPressed.ANY)
+	
+		if (FlxG.keys.justPressed.ESCAPE)
 		{
-			if (FlxG.keys.justPressed.ESCAPE)
-			{
-				MusicBeat.skipTrans = true;
-				MusicBeat.switchState(new states.menus.MainMenuState());
-			}
-			if (FlxG.keys.justPressed.F1)
-			{
-				FlxG.openURL('https://github.com/DoidoTeam/FNF-Doido-Engine/issues');
-			}
+			MusicBeatState.disableHotReload = false;
+			MusicBeat.skipTrans = true;
+			MusicBeat.switchState(new states.menus.MainMenuState());
+		}
+		if (FlxG.keys.justPressed.F1)
+		{
+			FlxG.openURL('https://github.com/DoidoTeam/FNF-Doido-Engine/issues');
 		}
 	}
+	
 }
+

--- a/source/doido/system/CrashHandler.hx
+++ b/source/doido/system/CrashHandler.hx
@@ -22,7 +22,8 @@ class CrashHandler extends MusicBeatState
 	override function create()
 	{
 		super.create();
-		MusicBeatState.disableHotReload = true;
+		hotReload = false;
+
 		var bg = new FlxSprite().loadGraphic(Assets.image('menuInvert'));
 		bg.screenCenter();
 		bg.alpha = 0.4;
@@ -67,7 +68,6 @@ class CrashHandler extends MusicBeatState
 	
 		if (FlxG.keys.justPressed.ESCAPE)
 		{
-			MusicBeatState.disableHotReload = false;
 			MusicBeat.skipTrans = true;
 			MusicBeat.switchState(new states.menus.MainMenuState());
 		}

--- a/source/states/LoadingState.hx
+++ b/source/states/LoadingState.hx
@@ -41,6 +41,7 @@ class LoadingState extends MusicBeatState
 	{
 		super.create();
 		persistentUpdate = true;
+		MusicBeatState.disableHotReload = true;
 
 		loadingTxtColor = (Save.data.darkMode ? "FFFFFF" : "000000");
 

--- a/source/states/LoadingState.hx
+++ b/source/states/LoadingState.hx
@@ -41,7 +41,7 @@ class LoadingState extends MusicBeatState
 	{
 		super.create();
 		persistentUpdate = true;
-		MusicBeatState.disableHotReload = true;
+		hotReload = false;
 
 		loadingTxtColor = (Save.data.darkMode ? "FFFFFF" : "000000");
 

--- a/source/states/PlayState.hx
+++ b/source/states/PlayState.hx
@@ -129,7 +129,6 @@ class PlayState extends MusicBeatState implements Playable
 		DiscordIO.changePresence("Playing - " + CHART.song);
 		persistentDraw = true;
 		persistentUpdate = false;
-		MusicBeatState.disableHotReload = false;
 		MusicBeat.stopMusic();
 
 		var scriptPaths:Array<String> = Assets.getScriptArray(CHART.song);

--- a/source/states/PlayState.hx
+++ b/source/states/PlayState.hx
@@ -129,6 +129,7 @@ class PlayState extends MusicBeatState implements Playable
 		DiscordIO.changePresence("Playing - " + CHART.song);
 		persistentDraw = true;
 		persistentUpdate = false;
+		MusicBeatState.disableHotReload = false;
 		MusicBeat.stopMusic();
 
 		var scriptPaths:Array<String> = Assets.getScriptArray(CHART.song);

--- a/source/states/editors/ChartingState.hx
+++ b/source/states/editors/ChartingState.hx
@@ -45,6 +45,7 @@ import doido.song.SongHandler;
 class ChartingNote extends Note
 {
 	public var selected:Bool = false;
+
 	public function new()
 	{
 		super();
@@ -112,7 +113,7 @@ class ChartingState extends MusicBeatState
 	override function create()
 	{
 		super.create();
-		MusicBeatState.disableHotReload = true;
+		hotReload = false;
 		setFpsPos(18, FlxG.height - 125 - Main.fpsHeight);
 		FlxG.mouse.visible = true;
 		Conductor.initialBPM = CHART.bpm;
@@ -237,7 +238,7 @@ class ChartingState extends MusicBeatState
 		// fileWindow.addSeparator();
 
 		// fileWindow.addButton("Open Events", "Ctrl + Alt + O");
-		// fileWindow.addSeparator();  
+		// fileWindow.addSeparator();
 		fileWindow.addButton("Open Song", () ->
 		{
 			var newSong:String = CHART.song;
@@ -766,7 +767,7 @@ class ChartingState extends MusicBeatState
 				};
 			}
 		});
-		
+
 		gfButton.x = getX("center", gfButton.width); // bfButton.width
 		gfButton.y = getY(12) + 32;
 		gfButton.button.setColorTransform(gfIcon.barColor.redFloat, gfIcon.barColor.greenFloat, gfIcon.barColor.blueFloat);

--- a/source/states/editors/ChartingState.hx
+++ b/source/states/editors/ChartingState.hx
@@ -45,7 +45,6 @@ import doido.song.SongHandler;
 class ChartingNote extends Note
 {
 	public var selected:Bool = false;
-
 	public function new()
 	{
 		super();
@@ -113,6 +112,7 @@ class ChartingState extends MusicBeatState
 	override function create()
 	{
 		super.create();
+		MusicBeatState.disableHotReload = true;
 		setFpsPos(18, FlxG.height - 125 - Main.fpsHeight);
 		FlxG.mouse.visible = true;
 		Conductor.initialBPM = CHART.bpm;
@@ -237,7 +237,7 @@ class ChartingState extends MusicBeatState
 		// fileWindow.addSeparator();
 
 		// fileWindow.addButton("Open Events", "Ctrl + Alt + O");
-		// fileWindow.addSeparator();
+		// fileWindow.addSeparator();  
 		fileWindow.addButton("Open Song", () ->
 		{
 			var newSong:String = CHART.song;
@@ -657,7 +657,7 @@ class ChartingState extends MusicBeatState
 		var bfIcon = new HealthIcon();
 		bfIcon.setIcon(META.player1, false);
 		bfIcon.globalScale = 0.33;
-		bfIcon.setPosition(getX() + 145 - bfIcon.width, getY(12));
+		bfIcon.setPosition(getX() + 145 - bfIcon.width, getY(12) - 10);
 		tab.add(bfIcon);
 
 		var bfButton = new DoidoTextButton("");
@@ -697,7 +697,7 @@ class ChartingState extends MusicBeatState
 		var oppIcon = new HealthIcon();
 		oppIcon.setIcon(META.player2, false);
 		oppIcon.globalScale = 0.33;
-		oppIcon.setPosition(getX("center", 145) + 145 - oppIcon.width, getY(12));
+		oppIcon.setPosition(getX("center", 145) + 145 - oppIcon.width, getY(12) - 10);
 		tab.add(oppIcon);
 
 		var oppButton = new DoidoTextButton("",);
@@ -737,7 +737,7 @@ class ChartingState extends MusicBeatState
 		var gfIcon = new HealthIcon();
 		gfIcon.setIcon(META.gf, false);
 		gfIcon.globalScale = 0.33;
-		gfIcon.setPosition(getX("margin_right", 145) + 145 - gfIcon.width, getY(12));
+		gfIcon.setPosition(getX("margin_right", 145) + 145 - gfIcon.width, getY(12) - 10);
 		tab.add(gfIcon);
 
 		var gfButton = new DoidoTextButton("");
@@ -1400,6 +1400,7 @@ class ChartingState extends MusicBeatState
 	{
 		if (testHere)
 			PlayState.startPos = Conductor.songPos;
+
 		PlayState.SONG = SONG;
 		MusicBeat.switchState(new LoadingState());
 		FlxG.mouse.visible = false;
@@ -1550,7 +1551,6 @@ class ChartingState extends MusicBeatState
 			var note:ChartingNote = cast renderNotes.recycle(ChartingNote);
 			note.loadData(noteData, noteskin + (quantNotes ? '-quant' : ''));
 			note.reloadSprite();
-
 			note.setGraphicSize(GRID_SIZE, GRID_SIZE);
 			note.updateHitbox();
 


### PR DESCRIPTION
Adds a variable to MusicBeatState that disables pressing F5 to reload on certain states if set to true.

Effects:
ChartingState, 
CrashHandlerState,
LoadingState.

PR also tweaks the position of the icons on the charting editor to be not clip into the buttons.