### PR TITLE
Custom formatMemory function for the memory Counter

### DIFF
--- a/source/doido/objects/system/FPSCounter.hx
+++ b/source/doido/objects/system/FPSCounter.hx
@@ -5,7 +5,7 @@ import openfl.system.System;
 import openfl.text.TextField;
 import openfl.text.TextFormat;
 import openfl.display.Sprite;
-import flixel.util.FlxStringUtil;
+import doido.utils.MemoryUtil;
 
 class FPSCounter extends Sprite
 {
@@ -75,12 +75,12 @@ class FPSCounter extends Sprite
 		fpsField.text = '$fps';
 		labelField.x = fpsField.x + fpsField.getLineMetrics(0).width + 4;
 
-		memField.text = FlxStringUtil.formatBytes(System.totalMemoryNumber);
+		memField.text = MemoryUtil.formatMemory(System.totalMemoryNumber);
 
 		if (debug)
 		{
 			#if windows
-			memField.text += ' / ${FlxStringUtil.formatBytes(doido.system.Windows.getMem())}';
+			memField.text += ' / ${MemoryUtil.formatMemory(doido.system.Windows.getMem())}';
 			#end
 
 			memField.text += '\n${Type.getClassName(Type.getClass(FlxG.state))}';
@@ -101,6 +101,7 @@ class FPSCounter extends Sprite
 		bg.width = bgWidth;
 		bg.height = bgHeight;
 	}
+
 }
 
 class CounterField extends TextField

--- a/source/doido/utils/MemoryUtil.hx
+++ b/source/doido/utils/MemoryUtil.hx
@@ -1,33 +1,23 @@
 package doido.utils;
-import flixel.math.FlxMath;
-class MemoryUtil 
+
+class MemoryUtil
 {
+	public static var units:Array<String> = ["B", "KB", "MB", "GB", "TB", "PB"];
+
 	/**
 	 * Version of flixel's formatBytes function so a new array isnt created each call.
-	 * @param Bytes 
-	 * @param Precision 
+	 * @param bytes
 	 * @return String
 	 */
-	inline public static function formatMemory(Bytes:Float, Precision:Int = 2):String
+	inline public static function formatMemory(bytes:Float):String
 	{
 		var curUnit = 0;
-		while (Bytes >= 1024)
+		while (bytes >= 1024)
 		{
-			Bytes /= 1024;
+			bytes /= 1024;
 			curUnit++;
 		}
-	   
-	    return FlxMath.roundDecimal(Bytes, Precision) + getUnits(curUnit);
+		
+		return (Math.fround(bytes * 100) / 100) + units[curUnit];
 	}
-
-    inline private static function getUnits(unit:Int)
-    {
-        switch(unit)
-		{
-			case 0:  return "Bytes";
-			case 1: return  "KB";
-			case 2: return  "MB";
-			default: return  "GB";
-		};
-    }
 }

--- a/source/doido/utils/MemoryUtil.hx
+++ b/source/doido/utils/MemoryUtil.hx
@@ -1,0 +1,33 @@
+package doido.utils;
+import flixel.math.FlxMath;
+class MemoryUtil 
+{
+	/**
+	 * Version of flixel's formatBytes function so a new array isnt created each call.
+	 * @param Bytes 
+	 * @param Precision 
+	 * @return String
+	 */
+	inline public static function formatMemory(Bytes:Float, Precision:Int = 2):String
+	{
+		var curUnit = 0;
+		while (Bytes >= 1024)
+		{
+			Bytes /= 1024;
+			curUnit++;
+		}
+	   
+	    return FlxMath.roundDecimal(Bytes, Precision) + getUnits(curUnit);
+	}
+
+    inline private static function getUnits(unit:Int)
+    {
+        switch(unit)
+		{
+			case 0:  return "Bytes";
+			case 1: return  "KB";
+			case 2: return  "MB";
+			default: return  "GB";
+		};
+    }
+}


### PR DESCRIPTION
Adds in a modified a formatBytes function that doesnt create an array each time called.