### PR TITLE
Small playfield note spawning fix

### DIFF
--- a/source/objects/ui/PlayField.hx
+++ b/source/objects/ui/PlayField.hx
@@ -110,25 +110,22 @@ class PlayField extends FlxGroup
 			Controls.released(RIGHT)
 			|| touchInput.released("right"),
 		];
-
 		if (!pressed.contains(true))
 			playerHolding = false;
 
 		// spawning notes
-		if (curSpawnNote < spawnNotes.length)
+		while(curSpawnNote < spawnNotes.length)
 		{
-			for (i in 0...spawnNotes.length)
+			var noteData = spawnNotes[curSpawnNote];
+			var strumline = strumlines[noteData.strumline];
+			if (noteDiffStep(noteData) < strumline.spawnStep) // spawns notes 32 steps ahead
 			{
-				if (i < curSpawnNote)
-					continue;
-
-				var noteData = spawnNotes[curSpawnNote];
-				var strumline = strumlines[noteData.strumline];
-				if (noteDiffStep(noteData) < strumline.spawnStep) // spawns notes 32 steps ahead
-				{
-					strumline.addNote(noteData);
-					curSpawnNote++;
-				}
+				strumline.addNote(noteData);
+				curSpawnNote++;
+			}
+			else
+			{
+				break;
 			}
 		}
 

--- a/source/objects/ui/PlayField.hx
+++ b/source/objects/ui/PlayField.hx
@@ -110,6 +110,7 @@ class PlayField extends FlxGroup
 			Controls.released(RIGHT)
 			|| touchInput.released("right"),
 		];
+		
 		if (!pressed.contains(true))
 			playerHolding = false;
 

--- a/source/objects/ui/PlayField.hx
+++ b/source/objects/ui/PlayField.hx
@@ -110,12 +110,12 @@ class PlayField extends FlxGroup
 			Controls.released(RIGHT)
 			|| touchInput.released("right"),
 		];
-		
+
 		if (!pressed.contains(true))
 			playerHolding = false;
 
 		// spawning notes
-		while(curSpawnNote < spawnNotes.length)
+		while (curSpawnNote < spawnNotes.length)
 		{
 			var noteData = spawnNotes[curSpawnNote];
 			var strumline = strumlines[noteData.strumline];
@@ -125,9 +125,7 @@ class PlayField extends FlxGroup
 				curSpawnNote++;
 			}
 			else
-			{
 				break;
-			}
 		}
 
 		for (strumline in strumlines)


### PR DESCRIPTION
Spawning notes loop no longer rechecks the entire array each frame but instead starts from the last spawned note.

This really doesn't do much apart from just reducing hundreds of pointless loop iterations.